### PR TITLE
Added binary storage option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ out/
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 
+# Eclipse
+/.classpath
+/.project
+*.prefs
+
+
 # JIRA plugin
 atlassian-ide-plugin.xml
 
@@ -110,6 +116,7 @@ gradle-app.setting
 .gradletasknamecache
 
 **/build/
+/bin/
 
 # Common working directory
 run/

--- a/src/main/java/dev/wwst/easyconomy/EasyConomyProvider.java
+++ b/src/main/java/dev/wwst/easyconomy/EasyConomyProvider.java
@@ -33,7 +33,7 @@ public class EasyConomyProvider implements Economy {
         else
             pds = new YamlDataStorage(config.getString("storage-location", "balances.yml"), config.getInt("baltopPlayers"));
 
-        if(Configuration.get().getBoolean("enable-logging",true))
+        if(config.getBoolean("enable-logging",true))
             logger = Easyconomy.getInstance().getLogger();
         else
             logger = null;

--- a/src/main/java/dev/wwst/easyconomy/Easyconomy.java
+++ b/src/main/java/dev/wwst/easyconomy/Easyconomy.java
@@ -5,6 +5,7 @@ import dev.wwst.easyconomy.commands.BaltopCommand;
 import dev.wwst.easyconomy.commands.EcoCommand;
 import dev.wwst.easyconomy.commands.PayCommand;
 import dev.wwst.easyconomy.events.JoinEvent;
+import dev.wwst.easyconomy.storage.PlayerDataStorage;
 import dev.wwst.easyconomy.utils.*;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;

--- a/src/main/java/dev/wwst/easyconomy/commands/BaltopCommand.java
+++ b/src/main/java/dev/wwst/easyconomy/commands/BaltopCommand.java
@@ -1,9 +1,9 @@
 package dev.wwst.easyconomy.commands;
 
 import dev.wwst.easyconomy.Easyconomy;
+import dev.wwst.easyconomy.storage.PlayerDataStorage;
 import dev.wwst.easyconomy.utils.Configuration;
 import dev.wwst.easyconomy.utils.MessageTranslator;
-import dev.wwst.easyconomy.utils.PlayerDataStorage;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;

--- a/src/main/java/dev/wwst/easyconomy/events/JoinEvent.java
+++ b/src/main/java/dev/wwst/easyconomy/events/JoinEvent.java
@@ -1,8 +1,8 @@
 package dev.wwst.easyconomy.events;
 
 import dev.wwst.easyconomy.Easyconomy;
+import dev.wwst.easyconomy.storage.PlayerDataStorage;
 import dev.wwst.easyconomy.utils.Configuration;
-import dev.wwst.easyconomy.utils.PlayerDataStorage;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -20,7 +20,7 @@ public class JoinEvent implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onJoin(PlayerJoinEvent e) {
         Bukkit.getScheduler().runTaskLater(Easyconomy.getInstance(), () -> {
-            if(!pds.getConfig().isSet(e.getPlayer().getUniqueId().toString())) {
+            if(!pds.has(e.getPlayer().getUniqueId())) {
                 final String cmd = "eco give "+e.getPlayer().getName()+" "+Configuration.get().getInt("startingBalance");
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(),cmd);
             }

--- a/src/main/java/dev/wwst/easyconomy/storage/BinaryDataStorage.java
+++ b/src/main/java/dev/wwst/easyconomy/storage/BinaryDataStorage.java
@@ -1,0 +1,194 @@
+package dev.wwst.easyconomy.storage;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+
+import dev.wwst.easyconomy.Easyconomy;
+import dev.wwst.easyconomy.utils.Configuration;
+
+/**
+ * An implementation of the PlayerDataStoarge that directly stores data in binary form.
+ *  This yields in a smaller file size and faster I/O speeds.
+ * @author Geolykt
+ */
+public class BinaryDataStorage implements PlayerDataStorage {
+
+    private final File file;
+    private final Map<UUID, Double> balances = new HashMap<>();
+
+    private final Easyconomy plugin;
+
+    private Map<UUID, Double> balTop;
+    private double smallestBalTop = Double.MAX_VALUE;
+
+    public BinaryDataStorage(String path, int baltopLength) {
+        plugin = (Easyconomy) Bukkit.getServer().getPluginManager().getPlugin(Easyconomy.PLUGIN_NAME);
+        plugin.getLogger().log(Level.INFO, "Loading Storage: " + path);
+        long timestamp = System.currentTimeMillis();
+
+        File storageFolder = new File(plugin.getDataFolder() + "/storage");
+        if (!storageFolder.exists())
+            storageFolder.mkdirs();
+
+        file = new File(plugin.getDataFolder() + "/storage", path);
+
+        if (!file.exists()) {
+            try {
+                file.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        reload();
+        plugin.addDataStorage(this);
+
+        if (baltopLength > 0) {
+            plugin.getLogger().info(
+                    "Calculating top balances... (if you have thousands of accounts, this could take a few seconds)");
+            recalcBaltop(balances, baltopLength);
+            plugin.getLogger().info(balTop.size() + " balances are now in the baltop.");
+        } else {
+            balTop = null;
+        }
+        timestamp = System.currentTimeMillis() - timestamp;
+        plugin.getLogger().log(Level.INFO, "Loaded Storage: " + path + " within " + timestamp + "ms");
+    }
+
+    @Override
+    public double getPlayerData(OfflinePlayer player) {
+        return balances.getOrDefault(player.getUniqueId(), 0.0);
+    }
+
+    @Override
+    public double getPlayerData(UUID player) {
+        return balances.getOrDefault(player, 0.0);
+    }
+
+    @Override
+    public List<UUID> getAllData() {
+        ArrayList<UUID> data = new ArrayList<>();
+        balances.forEach((id, balance) -> {
+            if (balance != null && balance != 0.0) {
+                data.add(id);
+            }
+        });
+        return data;
+    }
+
+    /*
+     ** Saves the current FileConfiguration to the file on the disk
+     */
+    @Override
+    public void save() {
+        long time = System.currentTimeMillis();
+        Configuration.get().options().copyDefaults(true);
+        try (FileOutputStream fileOut = new FileOutputStream(file)) {
+            fileOut.write(1);
+            for (Map.Entry<UUID, Double> entry : balances.entrySet()) {
+                fileOut.write(ByteBuffer.allocate(24)
+                        .putLong(entry.getKey().getLeastSignificantBits())
+                        .putLong(entry.getKey().getMostSignificantBits())
+                        .putDouble(entry.getValue())
+                        .array());
+            }
+            Easyconomy.getInstance().getLogger().info(
+                    "Storage file " + file.getName() + " saved within " + (System.currentTimeMillis() - time) + "ms.");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void write(UUID account, double balance) {
+        balances.put(account, balance);
+        if (balance > smallestBalTop) {
+            System.out.println(
+                    "Recalculating top balances (If you have a lot of accounts, this should happen very rarely)");
+            balTop.put(account, balance);
+            recalcBaltop(balTop, Configuration.get().getInt("baltopPlayers"));
+        }
+        Easyconomy.getInstance().getLogger()
+                .info("Write to " + account.toString() + ": " + balance + " and now saving.");
+        save();
+    }
+
+    private static byte[] streamReadAllBytes(InputStream stream) {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        int nRead;
+        byte[] data = new byte[16384]; // 16 * 1024 bytes = 16 KiB
+
+        try {
+            while ((nRead = stream.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return buffer.toByteArray();
+        }
+
+        return buffer.toByteArray();
+    }
+
+    @Override
+    public void reload() {
+        long time = System.currentTimeMillis();
+        try (FileInputStream fileIn = new FileInputStream(file)) {
+            if (fileIn.read() != 1) {
+                Easyconomy.getInstance().getLogger().warning("Storage file " + file.getName() + " has an invalid version."
+                        + " Reading it anyway.");
+            }
+            ByteBuffer buff = ByteBuffer.wrap(streamReadAllBytes(fileIn));
+            if (buff.array().length % 24 != 0) {
+                Easyconomy.getInstance().getLogger().severe("Storage file " + file.getName() + " has an invalid length."
+                        + " It's probably corrupted and the server will be disabled to prevent damage.");
+                Bukkit.shutdown();
+            }
+            balances.clear();
+            while (buff.hasRemaining()) {
+                balances.put(new UUID(buff.getLong(), buff.getLong()), buff.getDouble());
+            }
+            Easyconomy.getInstance().getLogger().info(
+                    "Storage file " + file.getName() + " loaded within " + (System.currentTimeMillis() - time) + "ms.");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void recalcBaltop(Map<UUID, Double> notSorted, int baltopLength) {
+        balTop = notSorted.entrySet().stream()
+                .sorted((c1, c2) -> -c1.getValue().compareTo(c2.getValue()))
+                .peek(val->{
+                    if(val.getValue() < smallestBalTop) smallestBalTop = val.getValue();})
+                .limit(baltopLength)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, HashMap::new));
+        if(balTop.size() < baltopLength) {
+            smallestBalTop = Double.MIN_VALUE;
+        }
+    }
+
+    @Override
+    public Map<UUID, Double> getBaltop() {
+        return balTop;
+    }
+
+    @Override
+    public boolean has(UUID key) {
+        return balances.containsKey(key);
+    }
+}

--- a/src/main/java/dev/wwst/easyconomy/storage/BinaryDataStorage.java
+++ b/src/main/java/dev/wwst/easyconomy/storage/BinaryDataStorage.java
@@ -101,8 +101,8 @@ public class BinaryDataStorage implements PlayerDataStorage {
             fileOut.write(1);
             for (Map.Entry<UUID, Double> entry : balances.entrySet()) {
                 fileOut.write(ByteBuffer.allocate(24)
-                        .putLong(entry.getKey().getLeastSignificantBits())
                         .putLong(entry.getKey().getMostSignificantBits())
+                        .putLong(entry.getKey().getLeastSignificantBits())
                         .putDouble(entry.getValue())
                         .array());
             }

--- a/src/main/java/dev/wwst/easyconomy/storage/BinaryDataStorage.java
+++ b/src/main/java/dev/wwst/easyconomy/storage/BinaryDataStorage.java
@@ -106,7 +106,7 @@ public class BinaryDataStorage implements PlayerDataStorage {
                         .putDouble(entry.getValue())
                         .array());
             }
-            Easyconomy.getInstance().getLogger().info(
+            plugin.getLogger().info(
                     "Storage file " + file.getName() + " saved within " + (System.currentTimeMillis() - time) + "ms.");
         } catch (IOException e) {
             e.printStackTrace();
@@ -122,8 +122,7 @@ public class BinaryDataStorage implements PlayerDataStorage {
             balTop.put(account, balance);
             recalcBaltop(balTop, Configuration.get().getInt("baltopPlayers"));
         }
-        Easyconomy.getInstance().getLogger()
-                .info("Write to " + account.toString() + ": " + balance + " and now saving.");
+        plugin.getLogger().info("Write to " + account.toString() + ": " + balance + " and now saving.");
         save();
     }
 
@@ -150,20 +149,23 @@ public class BinaryDataStorage implements PlayerDataStorage {
         long time = System.currentTimeMillis();
         try (FileInputStream fileIn = new FileInputStream(file)) {
             if (fileIn.read() != 1) {
-                Easyconomy.getInstance().getLogger().warning("Storage file " + file.getName() + " has an invalid version."
+                plugin.getLogger().warning("Storage file " + file.getName() + " has an invalid version."
                         + " Reading it anyway.");
             }
             ByteBuffer buff = ByteBuffer.wrap(streamReadAllBytes(fileIn));
             if (buff.array().length % 24 != 0) {
-                Easyconomy.getInstance().getLogger().severe("Storage file " + file.getName() + " has an invalid length."
-                        + " It's probably corrupted and the server will be disabled to prevent damage.");
-                Bukkit.shutdown();
+                plugin.getLogger().severe("Storage file " + file.getName() + " has an invalid length."
+                        + " It's probably corrupted and the plugin will be disabled to prevent damage.");
+                Bukkit.getPluginManager().disablePlugin(plugin);
+                // This forces the plugin to terminate and not to proceed any further, also showing a nice red wall
+                // of text so the sysadmin is aware of the crash.
+                throw new IOException("Unexpected file size. Possible corruption detected");
             }
             balances.clear();
             while (buff.hasRemaining()) {
                 balances.put(new UUID(buff.getLong(), buff.getLong()), buff.getDouble());
             }
-            Easyconomy.getInstance().getLogger().info(
+            plugin.getLogger().info(
                     "Storage file " + file.getName() + " loaded within " + (System.currentTimeMillis() - time) + "ms.");
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/dev/wwst/easyconomy/storage/PlayerDataStorage.java
+++ b/src/main/java/dev/wwst/easyconomy/storage/PlayerDataStorage.java
@@ -1,0 +1,33 @@
+package dev.wwst.easyconomy.storage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.OfflinePlayer;
+
+/**
+ * @author Weiiswurst
+ */
+public interface PlayerDataStorage {
+
+    public double getPlayerData(OfflinePlayer p);
+
+    public double getPlayerData(UUID player);
+
+    public List<UUID> getAllData();
+
+    /*
+     ** Saves the current FileConfiguration to the file on the disk
+     */
+    public void save();
+
+    public void write(UUID key, double value);
+
+    public void reload();
+
+    public Map<UUID, Double> getBaltop();
+    
+    public boolean has(UUID key);
+
+}

--- a/src/main/java/dev/wwst/easyconomy/utils/MessageTranslator.java
+++ b/src/main/java/dev/wwst/easyconomy/utils/MessageTranslator.java
@@ -83,21 +83,11 @@ public class MessageTranslator {
         }
     }
 
-    public String getMessageAndReplace(String key, boolean addPrefix, String... replacements) {
+    public String getMessageAndReplace(String key, boolean addPrefix, Object... replacements) {
         if(!messages.containsKey(key)) {
             return ChatColor.YELLOW+key+ ChatColor.RED +" not found!";
         }
-        String message = messages.get(key);
-        for(int i = 0; message.contains("%s") && replacements != null; i++) {
-            if(replacements.length <= i || replacements[i] == null) {
-                message = message.replaceFirst("%s", "&cNO REPLACEMENT");
-            } else {
-                message = message.replaceFirst("%s", replacements[i]);
-            }
-        }
-        if(addPrefix) {
-            message = prefix + message;
-        }
+        String message = (addPrefix ? prefix : "") + String.format(messages.get(key), replacements);
 
         return ChatColor.translateAlternateColorCodes('&', message);
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,6 +23,13 @@ permissions:
 
 startingBalance: 0
 
+# True if the binary mode should be used for storage.
+# Binary mode provides lower filesize (24 bytes per player) than the normal mode (45 bytes per player or more)
+# as well as faster saving (~1500ms rather than ~9000ms per million players) and loading (~1300ms rather than ~8500ms per million players) speeds.
+# A downside is that it's harder to repair damage to the file as well as editing things. USE BACKUPS!
+use-binary: false
+storage-location: "balances.yml"
+
 minimumTransactionAmount: 0.1
 # All decimals shown
 decimalsShown: -1
@@ -38,4 +45,4 @@ names:
 
 # Do not change this value.
 # This value makes sure that the config always updates when the plugin updates.
-CONFIG_VERSION_NEVER_CHANGE_THIS: 4
+CONFIG_VERSION_NEVER_CHANGE_THIS: 5


### PR DESCRIPTION
## Pros:
This option is significantly better than the current YAML storage in my benchmarks (with 1 million players databases).
 An improvement of around 7000ms (80% of the original value) is visible for both loading and saving 1 000 000 players, while I have to agree that 1 million players are a lot and won't be seen in normal production, it's also good for smaller servers because why not have a more optimised way of storing information? 

## Contras / Limitations
The solution only supports a bit more than 80 million players, after that it breaks due to JVM specifications (however most things would break at that point either way).
Additionally it writes data way too often and this should probably be fixed as that makes it pretty sensitive against corruption (maybe some automatic backup form). The I/O performance however is always better than the YAML implementations as of now

## Other notes
On the topic of backups, the resulting file can probably not be compressed to it's fullest extent (as we store ordering semi-randomly - however there's no need for order, so compressibility should be the main concern on ordering), but that is something to be aware of later.
I did not bump the plugin version myself, but I recommend to do so