### PR TITLE
 Allow for optional command execution on backups

### DIFF
--- a/src/main/java/dev/wwst/easyconomy/Easyconomy.java
+++ b/src/main/java/dev/wwst/easyconomy/Easyconomy.java
@@ -17,6 +17,7 @@ import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -72,8 +73,13 @@ public final class Easyconomy extends JavaPlugin {
 
         PluginManager pm = Bukkit.getPluginManager();
 
+        //Create backup folder
+        if (new File(getDataFolder(), "backups").mkdir()) {
+            saveResource("backups/onbackup.sh", false);
+        }
+
         getCommand("balance").setExecutor(new BalanceCommand());
-        getCommand("eco").setExecutor(new EcoCommand(ecp));
+        getCommand("eco").setExecutor(new EcoCommand(this, Configuration.get().getStringList("onbackup")));
         getCommand("pay").setExecutor(new PayCommand());
         getCommand("baltop").setExecutor(new BaltopCommand());
 

--- a/src/main/resources/backups/onbackup.sh
+++ b/src/main/resources/backups/onbackup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This shell script will be run everytime the plugin files are compiled. That is as long as it's referenced to run within the config.yml.
+# Below this paragraph is a command to compress the generated backups (.dat is assumed - change it to what you currently have) into a zstd compressed tarball. It was only tested by me on Fedora 33 (so GNU/linux), 
+# so I cannot gurantee that it would run anywhere else, which is why it's commented.
+
+# tar --remove-files -I "zstd --ultra -22" -cvf "backup-$(date +"%Y_%m_%d_%I_%M_%p").tar.zst" *.dat
+
+# Additionally you can perform more actions within this file to, for example ship the now compressed backups into a safe offsite location, but that's something you'll need to figure out yourself.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,6 +30,11 @@ startingBalance: 0
 use-binary: false
 storage-location: "balances.yml"
 
+# The shell command run within the backup folder to run after the files have been moved during a backup. Leave empty to run no command.
+# This is a single command and cannot do anything to complicated, if you have issues with it, outsource it into a script file.
+# Script files need to have 775 or similar in terms of permissions in order to work.
+onbackup: ["./onbackup.sh"]
+
 minimumTransactionAmount: 0.1
 # All decimals shown
 decimalsShown: -1

--- a/src/main/resources/messages_de.yml
+++ b/src/main/resources/messages_de.yml
@@ -1,4 +1,4 @@
-# German translation: Weiiswurst#0016
+# German translation: Weiiswurst#0016, Geolykt
 
 general:
   insufficientFunds: "&cDir fehlen &e%s&c, um das zu bezahlen!"
@@ -31,3 +31,4 @@ backup:
   starting: "&7Erstelle Backup, das kann einen Moment dauern"
   error: "&cBeim Erstellen des Backups ist ein Fehler aufgetreten."
   finished: "&aFertig!"
+  timeout: "&cDer Backup brauchte zu viel Zeit um fertiggestellt zu werden und wurde terminiert."

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -1,4 +1,4 @@
-# English translation: Weiiswurst#0016
+# English translation: Weiiswurst#0016, Geolykt
 
 general:
   insufficientFunds: "&cInsufficient funds! You need an additional &e%s &cto afford this payment!"
@@ -31,3 +31,4 @@ backup:
   starting: "&7Creating backup, please wait"
   error: "&cThere was an error while creating the backup."
   finished: "&aSuccess!"
+  timeout: "&cThe backup postprocess command took too long and was terminated."

--- a/src/main/resources/messages_fr.yml
+++ b/src/main/resources/messages_fr.yml
@@ -31,3 +31,4 @@ backup:
   starting: "&7Création d'une sauvegarde, attendez svp.."
   error: "&cIl y a eu une erreur durant la création de la sauvegarde !"
   finished: "&Sauvegarde effectuée !"
+  timeout: "&cIl y a eu une erreur durant la création de la sauvegarde !" # TODO use a less vague error.


### PR DESCRIPTION
This was originally intended for use of compression, however can be used for pretty much everything, from shipping the files to a remote location to just rm-ing the files for whatever reason.
The only issue right now is that it WILL perform a permission denied error on standard configuration settings if the file did not get a chmod, however since the command might never be performed it is quite likely that the exception will never be encountered for the general population.
The action is performed asynchronously so it has next to no effect on the main thread, however I still impose a 15 seconds limit in case the script hangs for whatever reason. It is also might be better if the rest is performed in async, but that's something for next time.